### PR TITLE
Fix stack overflow caused by escape parsing

### DIFF
--- a/src/patch.rs
+++ b/src/patch.rs
@@ -1120,6 +1120,7 @@ where
 	}
 
 	let steam_user_localconfig_str = steam_user_localconfig_str.unwrap();
+	let steam_user_localconfig_str = steam_user_localconfig_str.replace("\\\"", "'"); // Temp: Prevent stack overflow caused by escape parsing in "WebStorage" section. Related to Issue #54: https://github.com/CosmicHorrorDev/vdf-rs/issues
 	let steam_user_localconfig = vdf::from_str(steam_user_localconfig_str.as_str());
 
 	if let Err(error) = steam_user_localconfig {


### PR DESCRIPTION
GModPatchTool crashes with `thread 'main' has overflowed its stack` while attempting to parse localconfig.vdf. 

I worked out it's due to a section of the config (WebStorage) containing heaps of escaping `\"` which appears to be badly handled by `keyvalues-serde`, as detailed here https://github.com/CosmicHorrorDev/vdf-rs/issues/54 - The developer of `keyvalues-serde` is working on a fix but this hasn't yet made it into a stable release. 

Here's an example of a tiny part of the "LocalizedTagNames_english" value which is part of the "WebStorage" section (line breaks added for readability) 
```
{\"tagid\":5547,\"name\":\"Arena Shooter\"},{\"tagid\":5577,\"name\":\"RPGMaker\"},{\"tagid\":5608,\"name\":\"Emotional\"},
{\"tagid\":5611,\"name\":\"Mature\"},{\"tagid\":5613,\"name\":\"Detective\"},{\"tagid\":5652,\"name\":\"Collectathon\"},
{\"tagid\":5673,\"name\":\"Modern\"},{\"tagid\":5708,\"name\":\"Remake\"},{\"tagid\":5711,\"name\":\"Team-Based\"},
{\"tagid\":5716,\"name\":\"Mystery\"},{\"tagid\":5727,\"name\":\"Baseball\"},{\"tagid\":5752,\"name\":\"Robots\"},
{\"tagid\":5765,\"name\":\"Gun Customization\"},{\"tagid\":5794,\"name\":\"Science\"},{\"tagid\":5796,\"name\":\"Bullet Time\"},
{\"tagid\":5851,\"name\":\"Isometric\"},{\"tagid\":5900,\"name\":\"Walking Simulator\"},{\"tagid\":5914,\"name\":\"Tennis\"},
{\"tagid\":5923,\"name\":\"Dark Humor\"},{\"tagid\":5941,\"name\":\"Reboot\"},{\"tagid\":5981,\"name\":\"Mining\"},
{\"tagid\":5984,\"name\":\"Drama\"},{\"tagid\":6041,\"name\":\"Horses\"},{\"tagid\":6052,\"name\":\"Noir\"},
{\"tagid\":6129,\"name\":\"Logic\"},{\"tagid\":6214,\"name\":\"Birds\"},{\"tagid\":6276,\"name\":\"Inventory Management\"},
{\"tagid\":6310,\"name\":\"Diplomacy\"},{\"tagid\":6378,\"name\":\"Crime\"},{\"tagid\":6426,\"name\":\"Choices Matter\"},
{\"tagid\":6506,\"name\":\"3D Fighter\"},{\"tagid\":6621,\"name\":\"Pinball\"},{\"tagid\":6625,\"name\":\"Time Manipulation\"},
{\"tagid\":6650,\"name\":\"Nudity\"},{\"tagid\":6691,\"name\":\"1990's\"},{\"tagid\":6702,\"name\":\"Mars\"},
```
My "WebStorage" section contains over 15,000 instances of `\"`, vs 5 in the entire rest of the file.

As a temporary fix, this PR replaces the escaped `\"` with `'`. This stops the VDF parse from overflowing memory, and GModPatchTool runs successfully. This would not be a good solution if you wanted to look at values containing `\"`, but the patcher is only looking at the presence of `-nochromium` in the launch options, so I think this is fine.